### PR TITLE
Add arch-specific alias for the switcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /.build/
 /dist/
+
+.cabal-sandbox/
+cabal.sandbox.config

--- a/Main.hs
+++ b/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 
 module Main(main) where
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ There are two existing ways to get GHC on Windows, straight from the [GHC distri
 
 ## Possible future enhancements
 
-* Add support for 64-bit GHC.
 * Add in C libraries to ease use of Haskell packages on Windows. Pull requests welcome.
 
 ## Building the Installer
@@ -42,7 +41,7 @@ There are two existing ways to get GHC on Windows, straight from the [GHC distri
 Users of the installer have no need to build it, these are mostly notes for developers of the installer. To build one of the installers:
 
 * Download [NSIS](http://nsis.sourceforge.net/) and put it on your `%PATH%`.
-* Make sure you have copies of `tar`, `wget`, `bunzip` and `gzip` on your `%PATH%`. For `tar`, a version of BSD Tar is recommended.
+* Make sure you have copies of `tar`, `wget`, `bunzip` and `gzip` on your `%PATH%`. For `tar`, a version of BSD Tar is recommended. ([GNU on Windows (GOW)](https://github.com/bmatzelle/gow) might help you here.)
 * Run `cabal install`.
 * Run `minghc-generate`. That will generate a file `.build/minghc-7.8.3.exe` (takes about 10 minutes).
 * To build for other versions of GHC, pass the version on the command line, for example `minghc-generate 7.6.3`.


### PR DESCRIPTION
I'm happy to oblige changes you'd like. I built with GHC 7.10.1 and it complained about `Main.hs`, hence the addition of `FlexibleContexts` extension. I'm not sure what the proper solution is.

This is the minimal work to address #27.