### PR TITLE
Fix i386 release link for 7.8.4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It _does not_ provide all the packages included with the [Haskell Platform](http
 
 * [**Download installer with GHC 7.10.1 (32-bit)**](https://github.com/fpco/minghc/releases/download/2015-05-14/minghc-7.10.1-i386.exe)
 * [**Download installer with GHC 7.10.1 (64-bit)**](https://github.com/fpco/minghc/releases/download/2015-05-14/minghc-7.10.1-x86_64.exe)
-* [**Download installer with GHC 7.8.4 (32-bit)**](https://github.com/fpco/minghc/releases/download/2015-05-14/minghc-7.10.1-x86_64.exe)
+* [**Download installer with GHC 7.8.4 (32-bit)**](https://github.com/fpco/minghc/releases/download/2015-05-14/minghc-7.8.4-i386.exe)
 * [**Download installer with GHC 7.8.4 (64-bit)**](https://github.com/fpco/minghc/releases/download/2015-05-14/minghc-7.8.4-x86_64.exe)
 
 You may wish to also check the [Github latest releases page](https://github.com/fpco/minghc/releases/latest).


### PR DESCRIPTION
The i386 link for 7.8.4 in the current README.md points to 7.10.1 64bit.