### PR TITLE
Point to 2015-05-13

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ It _does not_ provide all the packages included with the [Haskell Platform](http
 
 ## Using the Installer
 
-* [**Download installer with GHC 7.10.2 (32-bit)**](https://github.com/fpco/minghc/releases/download/2015-08-05/minghc-7.10.2-i386.exe)
-* [**Download installer with GHC 7.10.2 (64-bit)**](https://github.com/fpco/minghc/releases/download/2015-08-05/minghc-7.10.2-x86_64.exe)
-* [**Download installer with GHC 7.8.4 (32-bit)**](https://github.com/fpco/minghc/releases/download/2015-08-05/minghc-7.8.4-i386.exe)
-* [**Download installer with GHC 7.8.4 (64-bit)**](https://github.com/fpco/minghc/releases/download/2015-08-05/minghc-7.8.4-x86_64.exe)
+* [**Download installer with GHC 7.10.2 (32-bit)**](https://github.com/fpco/minghc/releases/download/2015-08-13/minghc-7.10.2-i386.exe)
+* [**Download installer with GHC 7.10.2 (64-bit)**](https://github.com/fpco/minghc/releases/download/2015-08-13/minghc-7.10.2-x86_64.exe)
+* [**Download installer with GHC 7.8.4 (32-bit)**](https://github.com/fpco/minghc/releases/download/2015-08-13/minghc-7.8.4-i386.exe)
+* [**Download installer with GHC 7.8.4 (64-bit)**](https://github.com/fpco/minghc/releases/download/2015-08-13/minghc-7.8.4-x86_64.exe)
 
 You may wish to also check the [Github latest releases page](https://github.com/fpco/minghc/releases/latest).
 


### PR DESCRIPTION
I used the newest release of NSIS (version 3.0b2) on this so I'd like to get a little more testing than usual. So far I've been following this definition of "kick the tires":

  * Install MinGHC (on Windows 8.1 64-bit)
  * Run `stack setup` and make sure it uses GHC on `PATH`
  * Run `cabal update`
  * Run `cabal install network`. This usually produces an error when trying to clean up, but that's a known issue. The library does in fact install.